### PR TITLE
Update python_base.py

### DIFF
--- a/python_base.py
+++ b/python_base.py
@@ -763,8 +763,8 @@
     """
     
 #-- 包相对导入:使用点号(.) 只能使用from语句
-    from . import spam                  # 导入当前目录下的spam模块（错误: 当前目录下的模块, 直接导入即可）
-    from .spam import name              # 导入当前目录下的spam模块的name属性（错误: 当前目录下的模块, 直接导入即可，不用加.）
+    from . import spam                  # 导入当前目录下的spam模块（Python2: 当前目录下的模块, 直接导入即可）
+    from .spam import name              # 导入当前目录下的spam模块的name属性（Python2: 当前目录下的模块, 直接导入即可，不用加.）
     from .. import spam                 # 导入当前目录的父目录下的spam模块
     
 #-- 包相对导入与普通导入的区别


### PR DESCRIPTION
这里并非是错误，直接导入当前目录下的模块的方式叫隐式相对导入，在 Python2 中可用。但因为存在覆盖导入的问题，在 Python3 中禁止了隐式相对导入。

[PEP 328](https://www.python.org/dev/peps/pep-0328/#abstract):
> Imports can be ambiguous in the face of packages; within a package, it's not clear whether import foo refers to a module within the package or some module outside the package. (More precisely, a local module or package can shadow another hanging directly off sys.path .) 

> ... it is proposed that all import statements be absolute by default (searching sys.path only) with special syntax (leading dots) for accessing package-relative imports. 

[PEP 404](https://www.python.org/dev/peps/pep-0404/#imports):

> In Python 3, implicit relative imports within packages are no longer available - only absolute imports and explicit relative imports are supported. In addition, star imports (e.g. from x import * ) are only permitted in module level code. 